### PR TITLE
Leo/add confirm buttons to quick log action

### DIFF
--- a/src/ConfirmButtons.tsx
+++ b/src/ConfirmButtons.tsx
@@ -1,0 +1,20 @@
+import CheckIcon from "@mui/icons-material/Check";
+import ClearIcon from "@mui/icons-material/Clear";
+import { IconButton } from "@mui/material";
+
+type ConfirmButtonsProps = {
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+export function ConfirmButtons({ onConfirm, onCancel }: ConfirmButtonsProps) {
+  return (
+    <>
+      <IconButton onClick={onCancel}>
+        <ClearIcon fontSize="large" />
+      </IconButton>
+      <IconButton type="submit" onClick={onConfirm}>
+        <CheckIcon fontSize="large" />
+      </IconButton>
+    </>
+  );
+}

--- a/src/CreateLogger.tsx
+++ b/src/CreateLogger.tsx
@@ -1,8 +1,7 @@
-import { Box, Button, IconButton, TextField } from "@mui/material";
+import { Box, Button, TextField } from "@mui/material";
 import { FormEvent, useEffect, useRef, useState } from "react";
 
-import CheckIcon from "@mui/icons-material/Check";
-import ClearIcon from "@mui/icons-material/Clear";
+import { ConfirmButtons } from "./ConfirmButtons";
 
 type CreateLoggerProps = {
   onSubmit: (name: string) => void;
@@ -47,16 +46,13 @@ export function CreateLogger({ onSubmit }: CreateLoggerProps) {
             onChange={(e) => setName(e.target.value)}
             fullWidth
           />
-          <IconButton
-            onClick={() => {
+          <ConfirmButtons
+            onConfirm={() => {}}
+            onCancel={() => {
               setEditMode(false);
+              setName("");
             }}
-          >
-            <ClearIcon fontSize="large" />
-          </IconButton>
-          <IconButton type="submit">
-            <CheckIcon fontSize="large" />
-          </IconButton>
+          />
         </form>
       )}
     </Box>

--- a/src/LoggerListItem.tsx
+++ b/src/LoggerListItem.tsx
@@ -1,10 +1,12 @@
 import { Box, IconButton, Paper, Tooltip, Typography } from "@mui/material";
 
+import { ConfirmButtons } from "./ConfirmButtons";
 import { DeleteButton } from "./DeleteButton";
 import ElectricBoltIcon from "@mui/icons-material/ElectricBolt";
 import MenuOpenIcon from "@mui/icons-material/MenuOpen";
 import { useLoggerListContext } from "./LoggerListContext";
 import { useNavigate } from "react-router-dom";
+import { useState } from "react";
 
 type LoggerItemProps = {
   value: string;
@@ -20,6 +22,7 @@ export function LoggerListItem({
 }: LoggerItemProps) {
   const { handleAddToLog } = useLoggerListContext();
   const navigate = useNavigate();
+  const [confirmMode, setConfirmMode] = useState(false);
   return (
     <>
       <Paper
@@ -50,10 +53,25 @@ export function LoggerListItem({
               <FiEdit className="icon" />
             </button>
           )} */}
-          {!editMode && (
-            <IconButton onClick={() => handleAddToLog(logId, "")}>
+          {!editMode && !confirmMode && (
+            <IconButton
+              onClick={() => {
+                setConfirmMode(true);
+              }}
+            >
               <ElectricBoltIcon fontSize="large" />
             </IconButton>
+          )}
+          {!editMode && confirmMode && (
+            <ConfirmButtons
+              onConfirm={() => {
+                handleAddToLog(logId, "");
+                setConfirmMode(false);
+              }}
+              onCancel={() => {
+                setConfirmMode(false);
+              }}
+            />
           )}
           {editMode && <DeleteButton onClick={onDelete} />}
         </Box>


### PR DESCRIPTION
Moved the existing confirm buttons to their own component and then using them in the quick log action. This way it prevents accidental "quick logs", while still keeping the action fairly quick